### PR TITLE
SAGL-85: Add JWT authorizer

### DIFF
--- a/cdk/nbconvert_stack.py
+++ b/cdk/nbconvert_stack.py
@@ -91,19 +91,12 @@ class NBConvertLambdaCdkStack(Stack):
             certificate=certificate,
         )
 
-        api.add_stage(
-            id="default",
-            auto_deploy=True,
-            stage_name="$default"
-        )
-
         apigw2.ApiMapping(
             self,
             id="ApiMapping",
             api=api,
             domain_name=domain_name,
-            stage=api.default_stage,
-            api_mapping_key=base_path
+            stage=api.default_stage
         )
 
         CfnOutput(self, "ApiGatewayURL", value=api.url)

--- a/cdk/nbconvert_stack.py
+++ b/cdk/nbconvert_stack.py
@@ -5,6 +5,7 @@ from aws_cdk import (
     aws_certificatemanager as acm,
     aws_apigatewayv2 as apigw2,
     aws_apigatewayv2_integrations as apigw2_integrations,
+    aws_apigatewayv2_authorizers as apigw2_authorizers,
     aws_iam as iam,
     CfnOutput
 )
@@ -73,6 +74,12 @@ class NBConvertLambdaCdkStack(Stack):
             }
         )
 
+        jwt_auth = apigw2_authorizers.HttpJwtAuthorizer(
+            id="NBConvertJwtAuthorizer",
+            jwt_issuer=	"https://repo-prod.prod.sagebase.org/auth/v1",
+            jwt_audience=["0"]
+        )
+
         lambda_integration = apigw2_integrations.HttpLambdaIntegration(
             id="LambdaIntegration",
             handler=lambda_function
@@ -81,7 +88,8 @@ class NBConvertLambdaCdkStack(Stack):
         api.add_routes(
             path=f"/{base_path}",
             methods=[apigw2.HttpMethod.GET],
-            integration=lambda_integration
+            integration=lambda_integration,
+            authorizer=jwt_auth
         )
 
         domain_name = apigw2.DomainName(

--- a/cdk/nbconvert_stack.py
+++ b/cdk/nbconvert_stack.py
@@ -30,7 +30,8 @@ class NBConvertLambdaCdkStack(Stack):
             cert_arn = DEV_CERT_ARN
 
         self.lambda_fct = self.build_lambda_func(fct_stack=fct_stack)
-        self.setup_api_gateway = self.setup_api_gateway(lambda_function=self.lambda_fct,
+        self.setup_api_gateway = self.setup_api_gateway(fct_stack=fct_stack,
+                                                        lambda_function=self.lambda_fct,
                                                         domain_name=f"{domain_prefix}synapse.org",
                                                         cert_arn=cert_arn,
                                                         base_path="nbconvert")
@@ -53,6 +54,7 @@ class NBConvertLambdaCdkStack(Stack):
 
     def setup_api_gateway(
         self,
+        fct_stack: str,
         lambda_function: _lambda.DockerImageFunction,
         domain_name: str,
         cert_arn: str,
@@ -76,7 +78,7 @@ class NBConvertLambdaCdkStack(Stack):
 
         jwt_auth = apigw2_authorizers.HttpJwtAuthorizer(
             id="NBConvertJwtAuthorizer",
-            jwt_issuer=	"https://repo-prod.prod.sagebase.org/auth/v1",
+            jwt_issuer=	f"https://repo-prod.{fct_stack}.sagebase.org/auth/v1",
             jwt_audience=["0"]
         )
 

--- a/cdk/nbconvert_stack.py
+++ b/cdk/nbconvert_stack.py
@@ -62,7 +62,7 @@ class NBConvertLambdaCdkStack(Stack):
             certificate_arn=cert_arn
         )
 
-        allowed_origins = ["*"]
+        allowed_origins = ["https://dev.synapse.org"]
         if fct_stack == 'prod':
             allowed_origins = ["https://www.synapse.org", "https://synapse.org", "https://staging.synapse.org", "https://tst.synapse.org"]
 

--- a/cdk/nbconvert_stack.py
+++ b/cdk/nbconvert_stack.py
@@ -64,7 +64,7 @@ class NBConvertLambdaCdkStack(Stack):
 
         allowed_origins = ["*"]
         if fct_stack == 'prod':
-          allowed_origins = ["https://www.synapse.org", "https://synapse.org"]
+            allowed_origins = ["https://www.synapse.org", "https://synapse.org"]
 
         api = apigw2.HttpApi(
             self,

--- a/cdk/nbconvert_stack.py
+++ b/cdk/nbconvert_stack.py
@@ -64,7 +64,7 @@ class NBConvertLambdaCdkStack(Stack):
 
         allowed_origins = ["*"]
         if fct_stack == 'prod':
-            allowed_origins = ["https://www.synapse.org", "https://synapse.org"]
+            allowed_origins = ["https://www.synapse.org", "https://synapse.org", "https://staging.synapse.org", "https://tst.synapse.org"]
 
         api = apigw2.HttpApi(
             self,


### PR DESCRIPTION
This PR migrates the API Gateway infrastructure from REST API (v1) to HTTP API (v2) and adds JWT authorization for the nbconvert service. The changes enable token-based authentication using a Synapse-issued JWT authorizer while maintaining the existing Lambda function integration.

Key Changes:

    Replaced AWS API Gateway REST API (v1) with HTTP API (v2)
    Added JWT authorizer configured to validate tokens from Synapse authentication service
    Updated domain configuration and API route definitions to work with HTTP API v2
